### PR TITLE
Mock triage: needs author input

### DIFF
--- a/docs/mock-prs/needs-author-input.md
+++ b/docs/mock-prs/needs-author-input.md
@@ -1,0 +1,7 @@
+# Needs Author Input Mock PR
+
+This fixture intentionally leaves the proposed behavior under-specified.
+
+The change records that a maintainer saw a proposal, but it does not include
+acceptance criteria, user impact, validation evidence, affected surfaces, or a
+clear reason why the repository should accept the change.


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected classification: needs_author_input.

This PR intentionally omits acceptance criteria and validation evidence. It should exercise the missing-information path rather than the ready path.

Testing note: run the review labelling command and verify the label is `open-maintainer/needs-author-input`.