### PR TITLE
Mock triage: needs maintainer design

### DIFF
--- a/docs/mock-prs/maintainer-design-required.md
+++ b/docs/mock-prs/maintainer-design-required.md
@@ -1,0 +1,23 @@
+# Maintainer Design Required Mock PR
+
+This fixture proposes a product-policy decision rather than a bounded
+implementation task.
+
+Proposal:
+
+- Add organization-level automatic PR routing for all contribution-triage
+  categories.
+- Let repository owners define custom escalation rules for labels, comments,
+  and closure behavior.
+- Decide whether PR triage labels should be configurable per repository or
+  fixed to the Open Maintainer defaults.
+
+Open questions:
+
+- Which labels should be canonical versus repository-owned?
+- Which writes should be allowed from CLI, dashboard, Action, or GitHub App
+  contexts?
+- Which states require explicit human approval before mutation?
+
+This fixture should require maintainer design before implementation because it
+changes governance, permissions, and product policy.


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected classification: needs_maintainer_design.

This PR proposes governance and permission policy, but it is not an implementation-ready task. It should exercise the human design decision path.

Acceptance criteria for the mock:
- The PR is intentionally documentation-only.
- The proposed policy has unresolved maintainer decisions.
- The review should not mark it ready for normal implementation review.

Validation evidence:
- Docs-only fixture; no runtime validation required.