### PR TITLE
Mock triage: not agent ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# Mock PR fixture: this branch intentionally touches CI wiring so
+# contribution triage can exercise the not-agent-ready / high-risk path.
+
 on:
   push:
     branches:

--- a/docs/mock-prs/not-agent-ready.md
+++ b/docs/mock-prs/not-agent-ready.md
@@ -1,0 +1,17 @@
+# Not Agent Ready Mock PR
+
+This fixture intentionally touches CI wiring and asks for automation behavior
+without an implementation plan.
+
+Risk signals:
+
+- The branch changes `.github/workflows/ci.yml`.
+- The PR asks maintainers to reason about repository automation before handing
+  the work to an agent.
+- The PR should require explicit human review of the CI surface before any
+  coding-agent handoff.
+
+Validation:
+
+- CI workflow syntax review is required.
+- `bun lint`, `bun typecheck`, and `bun test` should remain required gates.


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected classification: not_agent_ready.

This branch intentionally touches CI wiring and should require human attention before any agent handoff. It is not meant to be merged.

Acceptance criteria for the mock:
- Changed surface includes `.github/workflows/ci.yml`.
- Review detects high-risk workflow changes.
- Label should not be ready-for-review unless a maintainer explicitly accepts the risk.

Validation evidence:
- Workflow syntax and CI gate review required.