### PR TITLE
Mock triage: failing CI

### DIFF
--- a/tests/mock-pr-triage-failing-ci.test.ts
+++ b/tests/mock-pr-triage-failing-ci.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("mock PR triage failing CI fixture", () => {
+  it("intentionally fails so PR labelling can detect failed checks", () => {
+    expect("failed-check-gate").toBe("ready");
+  });
+});


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected gate: failed checks must prevent `open-maintainer/ready-for-review`.

This PR intentionally adds a failing Vitest test. It is not meant to be merged.

Acceptance criteria for the mock:
- GitHub checks report failure.
- Review/labelling refuses ready-for-review even if the model tries to return ready_for_review.

Validation evidence:
- CI failure is the expected validation signal.