### PR TITLE
Mock triage: draft gate

### DIFF
--- a/docs/mock-prs/draft-blocker.md
+++ b/docs/mock-prs/draft-blocker.md
@@ -1,0 +1,11 @@
+# Draft PR Gate Mock
+
+This fixture is opened as a GitHub draft PR.
+
+Expected behavior:
+
+- Contribution triage may inspect the changed file and PR text.
+- The CLI must refuse `open-maintainer/ready-for-review` while GitHub reports
+  `isDraft: true`.
+- Maintainers can use this PR to verify the draft gate independently from CI
+  failure and merge conflict gates.


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected gate: draft status must prevent `open-maintainer/ready-for-review`.

This PR is intentionally opened as a draft. It is not meant to be merged.

Validation evidence:
- GitHub PR state should report `isDraft: true`.