### PR TITLE
Mock triage: changes requested gate

### DIFF
--- a/docs/mock-prs/changes-requested.md
+++ b/docs/mock-prs/changes-requested.md
@@ -1,0 +1,11 @@
+# Changes Requested Gate Mock
+
+This fixture is intended to receive a GitHub "request changes" review after the
+PR is opened.
+
+Expected behavior:
+
+- GitHub should report `reviewDecision: CHANGES_REQUESTED`.
+- The CLI must refuse `open-maintainer/ready-for-review` while changes are
+  requested.
+- The fixture isolates the review-decision gate from draft and conflict gates.


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected gate: requested changes must prevent `open-maintainer/ready-for-review`.

After opening, this PR receives a GitHub request-changes review to set `reviewDecision: CHANGES_REQUESTED`.

Validation evidence:
- GitHub review decision should report requested changes.