### PR TITLE
Mock triage: merge conflict gate

### DIFF
--- a/.open-maintainer/report.md
+++ b/.open-maintainer/report.md
@@ -34,7 +34,7 @@ Agent Readiness: 100/100
 - Evidence: docs/ROADMAP.md (detected repository context)
 - Evidence: docs/V0_3_RELEASE_REVIEW.md (detected repository context)
 - Evidence: docs/V0_4_RELEASE_REVIEW.md (detected repository context)
-- Evidence: local-docs/PRODUCT_PRD.md (detected repository context)
+- Evidence: docs/CONFLICTING_MOCK_PRD.md (mock conflicting repository context)
 - Evidence: README.md (detected repository context)
 - Evidence: .env.example (detected repository context)
 - Evidence: tests/fixtures/high-readiness-ts/.env.example (detected repository context)


### PR DESCRIPTION
Mock PR for v0.4.x contribution triage label testing.

Expected gate: merge conflicts must prevent `open-maintainer/ready-for-review`.

This branch was intentionally based on `origin/main~1` and edits the same generated report hunk changed on main, so GitHub should report the PR as conflicting or dirty. It is not meant to be merged.

Validation evidence:
- GitHub mergeability state is the expected signal.