### PR TITLE
Reduce lint job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   lint:
     name: Lint and format
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Reduces the lint job timeout so workflow failures surface faster when formatting or linting hangs.

Validation:
- Reviewed the workflow YAML diff locally.