### PR TITLE
Add review heading regression test

### DIFF
--- a/tests/review-copy-regression.test.ts
+++ b/tests/review-copy-regression.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("review copy", () => {
+  it("keeps the review heading stable", () => {
+    expect("OpenMaintainer Review").toBe("Open Maintainer Review");
+  });
+});


### PR DESCRIPTION
Adds a regression test around review heading copy so future rendering changes keep the heading stable.

Validation:
- Not run locally yet.