### PR TITLE
Refresh report evidence note

### DIFF
--- a/.open-maintainer/report.md
+++ b/.open-maintainer/report.md
@@ -34,7 +34,7 @@ Agent Readiness: 100/100
 - Evidence: docs/ROADMAP.md (detected repository context)
 - Evidence: docs/V0_3_RELEASE_REVIEW.md (detected repository context)
 - Evidence: docs/V0_4_RELEASE_REVIEW.md (detected repository context)
-- Evidence: local-docs/PRODUCT_PRD.md (detected repository context)
+- Evidence: docs/PRODUCT_NOTES.md (detected repository context)
 - Evidence: README.md (detected repository context)
 - Evidence: .env.example (detected repository context)
 - Evidence: tests/fixtures/high-readiness-ts/.env.example (detected repository context)


### PR DESCRIPTION
Updates one generated report evidence entry after moving product notes into the docs folder.

Validation:
- Reviewed the generated report diff locally.