### PR TITLE
Add version endpoint to low-context fixture

### DIFF
--- a/tests/fixtures/low-context-ts/src/server.ts
+++ b/tests/fixtures/low-context-ts/src/server.ts
@@ -3,5 +3,6 @@ import Fastify from "fastify";
 export function buildServer() {
   const app = Fastify({ logger: false });
   app.get("/health", async () => ({ ok: true }));
+  app.get("/version", async () => ({ version: "0.1.0" }));
   return app;
 }


### PR DESCRIPTION
Adds a `/version` endpoint to the low-context Fastify fixture.

No command output is included.
No test file was added for this endpoint.

This PR is intended to exercise automatic PR triage for a real code change that needs author follow-up before review.