### PR TITLE
Lower default issue triage batch size

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -51,7 +51,7 @@ export const OpenMaintainerConfigSchema = z.object({
               "closed",
               "security",
             ]),
-          maxIssues: z.number().int().positive().max(100).default(100),
+          maxIssues: z.number().int().positive().max(100).default(50),
         })
         .default({}),
       comments: z


### PR DESCRIPTION
Changes the default issue triage batch size from 100 issues to 50 issues.

This changes product/operator behavior and needs maintainer direction before normal code review.

No code-quality problem is claimed here; the point is to decide whether this default policy should change.