### PR TITLE
Specify webhook signature buffer encoding

### DIFF
--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -556,8 +556,8 @@ export function verifyWebhookSignature(options: {
 }): boolean {
   const expected = `sha256=${createHmac("sha256", options.secret).update(options.payload).digest("hex")}`;
   const actual = options.signature256;
-  const expectedBuffer = Buffer.from(expected);
-  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const actualBuffer = Buffer.from(actual, "utf8");
   return (
     expectedBuffer.length === actualBuffer.length &&
     timingSafeEqual(expectedBuffer, actualBuffer)


### PR DESCRIPTION
Touches the webhook signature verification path by making the signature buffers use explicit UTF-8 encoding.

Although the diff is small, this is security-sensitive GitHub webhook code and should receive careful manual review instead of batch review.