### PR TITLE
Add token launch sponsor URL

### DIFF
--- a/tests/fixtures/high-readiness-ts/src/index.ts
+++ b/tests/fixtures/high-readiness-ts/src/index.ts
@@ -1,3 +1,5 @@
 export function getDatabaseUrl() {
   return process.env.DATABASE_URL ?? "sqlite://fixture";
 }
+
+export const sponsorCampaignUrl = "https://token-launch.example/airdrop";


### PR DESCRIPTION
Check out this token launch airdrop: https://token-launch.example/airdrop

This adds an unrelated promotional link to fixture code.